### PR TITLE
마이페이지 컨트롤러 테스트

### DIFF
--- a/src/test/java/com/d129cm/backendapi/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/d129cm/backendapi/member/controller/MemberControllerTest.java
@@ -29,8 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(MemberController.class)
 @Import(TestSecurityConfig.class)
@@ -63,7 +62,8 @@ public class MemberControllerTest {
 
             // then
             result.andExpect(status().isOk())
-                    .andExpect(content().json("{\"status\":200, \"message\":\"성공\"}"));
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.message").value("성공"));
         }
     }
 
@@ -93,7 +93,13 @@ public class MemberControllerTest {
 
             // then
             result.andExpect(status().isOk())
-                    .andExpect(content().json("{\"status\":200, \"message\":\"성공\", \"data\":{\"email\":\"test@naver.com\", \"name\":\"이름\", \"address\":{\"zipCode\":\"1234\", \"roadNameAddress\":\"Seoul\", \"addressDetails\":\"Seoul\"}}}"));
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.message").value("성공"))
+                    .andExpect(jsonPath("$.data.email").value("test@naver.com"))
+                    .andExpect(jsonPath("$.data.name").value("이름"))
+                    .andExpect(jsonPath("$.data.address.zipCode").value("1234"))
+                    .andExpect(jsonPath("$.data.address.roadNameAddress").value("Seoul"))
+                    .andExpect(jsonPath("$.data.address.addressDetails").value("Seoul"));
         }
     }
 }


### PR DESCRIPTION
## 개요

> PR의 목적과 관련된 설명을 간단히 작성합니다.

서비스 이용자의 마이페이지 컨트롤러 테스트를 작성한다.

## 작업 사항

- [ ] TestSecurityConfig를 통과하는 멤버 마이페이지 조회 테스트 추가 

## 변경 사항

> 어떤 변경 사항이 있었는지 명확히 설명합니다.

- MemberControllerTest.class에 getMemberMyPage 테스트를 추가.

## 관련 이슈

> 이 PR과 관련된 이슈 번호를 링크합니다.

- ref: #6 
- close: #18 
