### PR TITLE
예외 처리 리팩토링

### DIFF
--- a/src/main/java/com/d129cm/backendapi/auth/utils/JwtProvider.java
+++ b/src/main/java/com/d129cm/backendapi/auth/utils/JwtProvider.java
@@ -58,14 +58,14 @@ public class JwtProvider {
         if (token.startsWith(BEARER_PREFIX)) {
             return token.substring(BEARER_PREFIX.length());
         }
-        throw new AuthenticationException(token);
+        throw AuthenticationException.unauthenticatedToken(token);
     }
 
     public void validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
         } catch (JwtException | IllegalArgumentException e) {
-            throw new AuthenticationException(token);
+            throw AuthenticationException.unauthenticatedToken(token);
         }
     }
 

--- a/src/main/java/com/d129cm/backendapi/common/exception/AuthenticationException.java
+++ b/src/main/java/com/d129cm/backendapi/common/exception/AuthenticationException.java
@@ -3,7 +3,14 @@ package com.d129cm.backendapi.common.exception;
 import org.springframework.http.HttpStatus;
 
 public class AuthenticationException extends BaseException {
-    public AuthenticationException(String token) {
-        super(String.format("토큰 : '%s'는 유효하지 않습니다.", token), HttpStatus.UNAUTHORIZED);
+    private static final String UNAUTHENTICATED_TOKEN = "토큰 '%s'는 유효하지 않습니다.";
+
+    public AuthenticationException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
     }
+
+    public static AuthenticationException unauthenticatedToken(String token) {
+        return new AuthenticationException(String.format(UNAUTHENTICATED_TOKEN, token));
+    }
+
 }

--- a/src/main/java/com/d129cm/backendapi/common/exception/ConflictException.java
+++ b/src/main/java/com/d129cm/backendapi/common/exception/ConflictException.java
@@ -3,7 +3,14 @@ package com.d129cm.backendapi.common.exception;
 import org.springframework.http.HttpStatus;
 
 public class ConflictException extends BaseException {
-    public ConflictException(String fieldName, String fieldValue) {
-        super(String.format("중복된 %s: '%s'은 중복된 값 입니다.", fieldName, fieldValue), HttpStatus.CONFLICT);
+    private static final String DUPLICATED_VALUE = "중복된 %s: '%s'은 중복된 값 입니다.";
+
+    public ConflictException(String message) {
+        super(message, HttpStatus.CONFLICT);
     }
+
+    public static ConflictException duplicatedValue(String fieldName, String fieldValue) {
+        return new ConflictException(String.format(DUPLICATED_VALUE, fieldName, fieldValue));
+    }
+
 }

--- a/src/main/java/com/d129cm/backendapi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/d129cm/backendapi/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.d129cm.backendapi.common.dto.CommonResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -30,45 +31,26 @@ public class GlobalExceptionHandler {
                 .map(error -> String.format("%s: %s", error.getField(), error.getDefaultMessage()))
                 .collect(Collectors.joining(", "));
 
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(CommonResponse.failure(HttpStatus.BAD_REQUEST, errorMessage));
-    }
-
-    @ExceptionHandler(ConflictException.class)
-    public final ResponseEntity<?> handleConflictException(ConflictException e, HttpServletRequest request) {
-        log.warn("source = {} {}, message = {}",
-                request.getMethod(), request.getRequestURI(), e.getMessage());
-        return ResponseEntity
-                .status(e.getStatus())
-                .body(CommonResponse.failure(e.getStatus(), e.getMessage()));
-    }
-
-    @ExceptionHandler(AuthenticationException.class)
-    public final ResponseEntity<?> handleAuthenticationException(AuthenticationException e, HttpServletRequest request) {
-        log.warn("source = {} {}, message = {}",
-                request.getMethod(), request.getRequestURI(), e.getMessage());
-        return ResponseEntity
-                .status(e.getStatus())
-                .body(CommonResponse.failure(e.getStatus(), e.getMessage()));
+        return buildResponseEntity(HttpStatus.BAD_REQUEST, errorMessage);
     }
 
     @ExceptionHandler(BaseException.class)
-    public final ResponseEntity<?> handleFinderException(BaseException e, HttpServletRequest request) {
+    public final ResponseEntity<CommonResponse<Void>> handle129cmException(BaseException e, HttpServletRequest request) {
         log.warn("source = {} {}, message = {}",
                 request.getMethod(), request.getRequestURI(), e.getMessage());
-        return ResponseEntity
-                .status(e.getStatus())
-                .body(CommonResponse.failure(e.getStatus(), e.getMessage()));
+        return buildResponseEntity(e.getStatus(), e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
     public final ResponseEntity<CommonResponse<Void>> handleDefaultExceptions(Exception e, HttpServletRequest request) {
         log.error("source = {} {}, message = {}",
                 request.getMethod(), request.getRequestURI(), e.getMessage(), e);
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(CommonResponse.failure(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR"));
+        return buildResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
     }
 
+    private static ResponseEntity<CommonResponse<Void>> buildResponseEntity(HttpStatusCode statusCode, String message) {
+        return ResponseEntity
+                .status(statusCode)
+                .body(CommonResponse.failure(statusCode, message));
+    }
 }

--- a/src/main/java/com/d129cm/backendapi/member/service/MemberService.java
+++ b/src/main/java/com/d129cm/backendapi/member/service/MemberService.java
@@ -25,7 +25,7 @@ public class MemberService {
     public void saveMember(MemberSignupRequest request) {
         Password newPassword = Password.of(request.password(), passwordEncoder);
         if (memberRepository.existsByEmail(request.email())) {
-            throw new ConflictException("email", request.email());
+            throw ConflictException.duplicatedValue("email", request.email());
         }
 
         Member newMember = Member.builder()

--- a/src/main/java/com/d129cm/backendapi/partners/service/PartnersService.java
+++ b/src/main/java/com/d129cm/backendapi/partners/service/PartnersService.java
@@ -24,7 +24,7 @@ public class PartnersService {
 
     public void savePartners(PartnersSignupRequest request) {
         if (partnersRepository.existsByEmail(request.email())) {
-            throw new ConflictException("email", request.email());
+            throw ConflictException.duplicatedValue("email", request.email());
         }
 
         Password encodedPassword = Password.of(request.password(), passwordEncoder);

--- a/src/test/java/com/d129cm/backendapi/common/aop/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/d129cm/backendapi/common/aop/GlobalExceptionHandlerTest.java
@@ -32,8 +32,12 @@ public class GlobalExceptionHandlerTest {
     @Test
     void 실패409반환_ConflictException_발생() throws Exception {
         // given
+        String fieldName = "fieldName";
+        String fieldValue = "fieldValue";
+        String message = String.format("중복된 %s: '%s'은 중복된 값 입니다.", fieldName, fieldValue);
+
         // when
-        when(controller.healthCheck()).thenThrow(new ConflictException("fieldName", "fieldValue"));
+        when(controller.healthCheck()).thenThrow(new ConflictException(message));
 
         // then
         mockMvc.perform(MockMvcRequestBuilders.get("/ping"))
@@ -45,8 +49,11 @@ public class GlobalExceptionHandlerTest {
     @Test
     void 실패401반환_AuthenticationException_발생() throws Exception {
         // given
+        String token = "invalidToken";
+        String message = String.format("토큰 '%s'는 유효하지 않습니다.", token);
+
         // when
-        when(controller.healthCheck()).thenThrow(new AuthenticationException("Token"));
+        when(controller.healthCheck()).thenThrow(new AuthenticationException(message));
 
         // then
         mockMvc.perform(MockMvcRequestBuilders.get("/ping"))

--- a/src/test/java/com/d129cm/backendapi/partners/controller/PartnersControllerTest.java
+++ b/src/test/java/com/d129cm/backendapi/partners/controller/PartnersControllerTest.java
@@ -85,7 +85,7 @@ public class PartnersControllerTest {
         void status409_이메일_중복() throws Exception {
             // given
             PartnersSignupRequest request = new PartnersSignupRequest("email@naver.com", "Asdf123!", "123-12-12312");
-            ConflictException e = new ConflictException("email", request.email());
+            ConflictException e = ConflictException.duplicatedValue("email", request.email());
 
             doThrow(e).when(partnersService).savePartners(request);
 

--- a/src/test/java/com/d129cm/backendapi/partners/service/PartnersServiceTest.java
+++ b/src/test/java/com/d129cm/backendapi/partners/service/PartnersServiceTest.java
@@ -59,7 +59,7 @@ public class PartnersServiceTest {
         void 예외반환_중복된_파트너스() {
             // given
             PartnersSignupRequest request = new PartnersSignupRequest("email@naver.com", "asdf1234!", "123-45-67890");
-            ConflictException e = new ConflictException("email", request.email());
+            ConflictException e = ConflictException.duplicatedValue("email", request.email());
 
             // when
             when(partnersRepository.existsByEmail(request.email())).thenReturn(true);


### PR DESCRIPTION
## 개요

> PR의 목적과 관련된 설명을 간단히 작성합니다.

## 작업 사항

- [ ] 예외 처리 리팩토링 

## 변경 사항

> 어떤 변경 사항이 있었는지 명확히 설명합니다.

- BaseException을 상속받는 모든 예외는 handleBaseExceptions 메서드에서 처리하도록 한다.
- buildResponseEntity 메서드를 사용하여 중복 코드를 제거한다.
- BaseException을 상속받는 모든 예외는 정적 팩토리 메서드 사용 + 예외 메시지는 파라미터로 -> 다양한 오류 처리

## 관련 이슈

> 이 PR과 관련된 이슈 번호를 링크합니다.

- close: #31 
