### PR TITLE
401, 403 시큐리티 예외처리 등록

### DIFF
--- a/src/main/java/com/d129cm/backendapi/auth/config/CommonSecurityConfig.java
+++ b/src/main/java/com/d129cm/backendapi/auth/config/CommonSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.d129cm.backendapi.auth.config;
 
+import com.d129cm.backendapi.auth.filter.CustomAccessDeniedHandler;
+import com.d129cm.backendapi.auth.filter.CustomAuthenticationEntryPoint;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,12 +25,15 @@ public class CommonSecurityConfig {
 
         http.authorizeHttpRequests(common -> common
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                .requestMatchers(HttpMethod.GET, "/ping").permitAll()
-                .requestMatchers(HttpMethod.GET, "/error").permitAll()
+                .requestMatchers(HttpMethod.GET, "/ping", "/error").permitAll()
                 .anyRequest().denyAll());
 
         http.formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable);
+
+        http.exceptionHandling(exception -> exception
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
 
         return http.build();
     }

--- a/src/main/java/com/d129cm/backendapi/auth/config/MemberSecurityConfig.java
+++ b/src/main/java/com/d129cm/backendapi/auth/config/MemberSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.d129cm.backendapi.auth.config;
 
+import com.d129cm.backendapi.auth.filter.CustomAccessDeniedHandler;
+import com.d129cm.backendapi.auth.filter.CustomAuthenticationEntryPoint;
 import com.d129cm.backendapi.auth.filter.JwtAuthorizationFilter;
 import com.d129cm.backendapi.auth.filter.MemberJwtLoginFilter;
 import com.d129cm.backendapi.auth.service.MemberDetailsService;
@@ -93,6 +95,10 @@ public class MemberSecurityConfig {
 
         http.addFilterBefore(new MemberJwtLoginFilter(jwtProvider, memberAuthenticationManager()), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new JwtAuthorizationFilter(jwtProvider, memberDetailsService, ignoredRequests), MemberJwtLoginFilter.class);
+
+        http.exceptionHandling(exception -> exception
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
 
         return http.build();
     }

--- a/src/main/java/com/d129cm/backendapi/auth/config/PartnersSecurityConfig.java
+++ b/src/main/java/com/d129cm/backendapi/auth/config/PartnersSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.d129cm.backendapi.auth.config;
 
+import com.d129cm.backendapi.auth.filter.CustomAccessDeniedHandler;
+import com.d129cm.backendapi.auth.filter.CustomAuthenticationEntryPoint;
 import com.d129cm.backendapi.auth.filter.JwtAuthorizationFilter;
 import com.d129cm.backendapi.auth.filter.PartnersJwtLoginFilter;
 import com.d129cm.backendapi.auth.service.PartnersDetailsService;
@@ -74,6 +76,10 @@ public class PartnersSecurityConfig {
 
         http.addFilterBefore(new PartnersJwtLoginFilter(jwtProvider, partnersAuthenticationManager()), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new JwtAuthorizationFilter(jwtProvider, partnersDetailsService, ignoredRequests), PartnersJwtLoginFilter.class);
+
+        http.exceptionHandling(exception -> exception
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
 
         return http.build();
     }

--- a/src/main/java/com/d129cm/backendapi/auth/filter/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/d129cm/backendapi/auth/filter/CustomAccessDeniedHandler.java
@@ -1,0 +1,23 @@
+package com.d129cm.backendapi.auth.filter;
+
+import com.d129cm.backendapi.common.dto.CommonResponse;
+import com.d129cm.backendapi.common.utils.ServletResponseUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        log.info(accessDeniedException.getMessage());
+        CommonResponse<?> errorResponse = CommonResponse.failure(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+
+        ServletResponseUtil.servletResponse(response, errorResponse);
+    }
+}

--- a/src/main/java/com/d129cm/backendapi/auth/filter/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/d129cm/backendapi/auth/filter/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package com.d129cm.backendapi.auth.filter;
+
+import com.d129cm.backendapi.common.dto.CommonResponse;
+import com.d129cm.backendapi.common.utils.ServletResponseUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        log.info(authException.getMessage());
+        CommonResponse<?> errorResponse = CommonResponse.failure(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+
+        ServletResponseUtil.servletResponse(response, errorResponse);
+    }
+}

--- a/src/main/java/com/d129cm/backendapi/auth/utils/JwtProvider.java
+++ b/src/main/java/com/d129cm/backendapi/auth/utils/JwtProvider.java
@@ -9,12 +9,9 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import java.security.Key;
 import java.util.Date;
@@ -43,15 +40,6 @@ public class JwtProvider {
                 .claim("role", role)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
-    }
-
-    public String getJwtFromHeader(HttpServletRequest request) {
-        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return removeBearerPrefix(bearerToken);
-        }
-
-        return null;
     }
 
     public String removeBearerPrefix(String token) {

--- a/src/test/java/com/d129cm/backendapi/common/aop/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/d129cm/backendapi/common/aop/GlobalExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(HealthCheckController.class)
 @Import({GlobalExceptionHandler.class, TestSecurityConfig.class})
+@SuppressWarnings("NonAsciiCharacters")
 public class GlobalExceptionHandlerTest {
 
     @Autowired
@@ -49,8 +50,8 @@ public class GlobalExceptionHandlerTest {
     @Test
     void 실패401반환_AuthenticationException_발생() throws Exception {
         // given
-        String token = "invalidToken";
-        String message = String.format("토큰 '%s'는 유효하지 않습니다.", token);
+        String token = "Token";
+        String message = String.format("토큰 : '%s'는 유효하지 않습니다.", token);
 
         // when
         when(controller.healthCheck()).thenThrow(new AuthenticationException(message));

--- a/src/test/java/com/d129cm/backendapi/partners/controller/PartnersControllerTest.java
+++ b/src/test/java/com/d129cm/backendapi/partners/controller/PartnersControllerTest.java
@@ -8,11 +8,11 @@ import com.d129cm.backendapi.auth.utils.JwtProvider;
 import com.d129cm.backendapi.brand.dto.BrandResponse;
 import com.d129cm.backendapi.common.dto.CommonResponse;
 import com.d129cm.backendapi.common.exception.ConflictException;
+import com.d129cm.backendapi.partners.domain.Partners;
 import com.d129cm.backendapi.partners.dto.PartnersMyPageResponse;
 import com.d129cm.backendapi.partners.dto.PartnersSignupRequest;
 import com.d129cm.backendapi.partners.service.PartnersService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,6 +25,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -38,7 +40,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PartnersController.class)
-@Import({PartnersSecurityConfig.class, JwtProvider.class})
+@Import({PartnersSecurityConfig.class})
 @SuppressWarnings("NonAsciiCharacters")
 public class PartnersControllerTest {
 
@@ -56,11 +58,6 @@ public class PartnersControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider;
-
-    @BeforeEach
-    void setUp() {
-        when(passwordEncoder.encode(any())).thenReturn("encodedPassword");
-    }
 
     @Nested
     class signup {
@@ -145,9 +142,9 @@ public class PartnersControllerTest {
             // given
             String mockToken = "token";
             PartnersMyPageResponse response = new PartnersMyPageResponse("test@email.com", "123-45-67890", mock(BrandResponse.class));
-            when(partnersDetailsService.loadUserByUsername("partners")).thenReturn(mock(PartnersDetails.class));
+            when(partnersDetailsService.loadUserByUsername("partners")).thenReturn(spy(new PartnersDetails(mock(Partners.class))));
             when(partnersService.getPartnersMyPage(any())).thenReturn(response);
-            when(jwtProvider.getJwtFromHeader(any())).thenReturn(mockToken);
+            when(jwtProvider.removeBearerPrefix(mockToken)).thenReturn(mockToken);
             when(jwtProvider.getRoleFromToken(mockToken)).thenReturn(Role.ROLE_PARTNERS);
             when(jwtProvider.getSubjectFromToken(mockToken)).thenReturn("partners");
 
@@ -155,7 +152,7 @@ public class PartnersControllerTest {
             ResultActions result = mockMvc.perform(get("/partners")
                     .contentType(MediaType.APPLICATION_JSON)
                     .characterEncoding(StandardCharsets.UTF_8)
-                    .header("Authorization", "Bearer token")
+                    .header("Authorization", mockToken)
             );
 
             // then
@@ -164,7 +161,48 @@ public class PartnersControllerTest {
                     .andExpect(jsonPath("$.message").value("성공"))
                     .andExpect(jsonPath("$.data.email").value(response.email()))
                     .andExpect(jsonPath("$.data.businessNumber").value(response.businessNumber()));
-
         }
+
+        @Test
+        @WithMockUser(username = "member", authorities = {"ROLE_MEMBER"})
+        void 실패403_일반_멤버가_파트너스의_개인_정보_조회() throws Exception {
+            // given
+            String token = "Members token";
+            when(jwtProvider.removeBearerPrefix(token)).thenReturn(token);
+            when(jwtProvider.getRoleFromToken(token)).thenReturn(Role.ROLE_MEMBER);
+            when(jwtProvider.getSubjectFromToken(token)).thenReturn("member");
+
+            Partners partners = mock(Partners.class);
+            PartnersDetails partnersDetails = spy(new PartnersDetails(partners));
+            when(partnersDetailsService.loadUserByUsername("member")).thenReturn(partnersDetails);
+            when(partnersDetails.getAuthorities()).thenCallRealMethod();
+
+            // when
+            ResultActions result = mockMvc.perform(get("/partners")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(StandardCharsets.UTF_8)
+                    .header("Authorization", token)
+            );
+
+            // then
+            result.andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value(403))
+                    .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+        }
+
+        @Test
+        @WithAnonymousUser
+        void 실패401_인증되지_않은_사용자() throws Exception {
+            // when
+            ResultActions result = mockMvc.perform(get("/partners")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(StandardCharsets.UTF_8)
+            );
+
+            // then
+            result.andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value(401));
+        }
+
     }
 }


### PR DESCRIPTION
## 개요

> PR의 목적과 관련된 설명을 간단히 작성합니다.

## 작업 사항

- [x] AuthenticationEntryPoint 커스텀 등록
- [x] AccessDeniedHandler 커스텀 등록
- [x] partners 회원조회로 401, 403 테스트

## 변경 사항

> 어떤 변경 사항이 있었는지 명확히 설명합니다.

- CustomAuthenticationEntryPoint, CustomAccessDeniedHandler 추가
- 각 SecurityConfig 파일에 해당 exceptionHandler 등록
- 401, 403 이슈 테스트 추가
- JwtAuthorizationFilter에서 exception 발생 시 SecurityContext 클리어하지 않음. 추후에 Exception 세분화 고려

## 관련 이슈

> 이 PR과 관련된 이슈 번호를 링크합니다.

- close: #20 
